### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/github-integration-santaji/5191b74c-9f4c-467c-a1cb-ef165ebfbeac/c986efca-6538-49e7-9b21-9da2b3a54b4f/_apis/work/boardbadge/b84d2ef6-cc04-4490-92ac-b7991cbcb5aa)](https://dev.azure.com/github-integration-santaji/5191b74c-9f4c-467c-a1cb-ef165ebfbeac/_boards/board/t/c986efca-6538-49e7-9b21-9da2b3a54b4f/Microsoft.RequirementCategory)
 # az-ws

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 [![Board Status](https://dev.azure.com/github-integration-santaji/5191b74c-9f4c-467c-a1cb-ef165ebfbeac/c986efca-6538-49e7-9b21-9da2b3a54b4f/_apis/work/boardbadge/b84d2ef6-cc04-4490-92ac-b7991cbcb5aa)](https://dev.azure.com/github-integration-santaji/5191b74c-9f4c-467c-a1cb-ef165ebfbeac/_boards/board/t/c986efca-6538-49e7-9b21-9da2b3a54b4f/Microsoft.RequirementCategory)
+
 # az-ws


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/github-integration-santaji/5191b74c-9f4c-467c-a1cb-ef165ebfbeac/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.